### PR TITLE
Fix typo in StationService variable name

### DIFF
--- a/src/main/java/de/alcantara/betriebsstellen/service/StationService.java
+++ b/src/main/java/de/alcantara/betriebsstellen/service/StationService.java
@@ -10,8 +10,8 @@ import de.alcantara.betriebsstellen.utilities.StationMapper;
 public class StationService {
 
 	public static StationReturn findByCode(String code) {
-		List<Station> statonList = CSVParser.parse();
-		for (Station s : statonList) {
+                List<Station> stationList = CSVParser.parse();
+                for (Station s : stationList) {
 			if (s.getCode().equals(code)) {
 				return StationMapper.map(s);
 			}


### PR DESCRIPTION
## Summary
- rename `statonList` to `stationList` in `StationService.findByCode`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68972b8d4f308322bbeedd812199e7c8